### PR TITLE
Support for proxy auth and small fix to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The complete list of options to `globalTunnel.initialize`:
 
 - **host** - the hostname or IP of the HTTP proxy to use
 - **port** - the TCP port to use on that proxy
-- **tunnel** _(optional)_ controls what protocols use the `CONNECT` method.  It
+- **connect** _(optional)_ controls what protocols use the `CONNECT` method.  It
   has three possible values (strings):
   - **neither** - don't use `CONNECT`; just use absolute URIs
   - **https** - _(the default)_ only use `CONNECT` for HTTPS requests
@@ -81,12 +81,12 @@ Host: example.com
 GET https://example.com/ HTTP/1.1
 ```
 
-You'll need to specify `tunnel: 'neither'` if this is the case.  If the proxy
+You'll need to specify `connect: 'neither'` if this is the case.  If the proxy
 speaks HTTP (i.e. the connection from node --> proxy is not encrypted):
 
 ```js
 globalTunnel.initialize({
-  tunnel: 'neither',
+  connect: 'neither',
   host: '10.0.0.10',
   port: 3128
 });
@@ -96,7 +96,7 @@ or, if the proxy speaks HTTPS to your app instead:
 
 ```js
 globalTunnel.initialize({
-  tunnel: 'neither',
+  connect: 'neither',
   protocol: 'https:'
   host: '10.0.0.10',
   port: 3129
@@ -106,7 +106,7 @@ globalTunnel.initialize({
 ### Always-CONNECT Proxies
 
 If the proxy expects you to use the `CONNECT` method for both HTTP and HTTPS
-requests, you'll need the `tunnel: 'both'` option.
+requests, you'll need the `connect: 'both'` option.
 
 What does this mean?  It means that instead of ...
 
@@ -124,7 +124,7 @@ Be sure to set the `protocol:` option based on what protocol the proxy speaks.
 
 ```js
 globalTunnel.initialize({
-  tunnel: 'both',
+  connect: 'both',
   host: '10.0.0.10',
   port: 3130
 });
@@ -139,7 +139,7 @@ for the two phases of the connection.
 
 ```js
 globalTunnel.initialize({
-  tunnel: 'both',
+  connect: 'both',
   protocol: 'https:'
   host: '10.0.0.10',
   port: 3130,

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ function tryParse(url) {
   conf.protocol = parsed.protocol;
   conf.host = parsed.hostname;
   conf.port = parseInt(parsed.port,10);
+  conf.proxyAuth = parsed.auth;
   return conf;
 }
 
@@ -139,7 +140,7 @@ globalTunnel._makeAgent = function(conf, innerProtocol, useCONNECT) {
   innerProtocol = innerProtocol + ':';
 
   var opts = {
-    proxy: _.pick(conf, 'host','port','protocol','localAddress'),
+    proxy: _.pick(conf, 'host','port','protocol','localAddress', 'proxyAuth'),
     maxSockets: conf.sockets
   };
   opts.proxy.innerProtocol = innerProtocol;


### PR DESCRIPTION
Hi, I added support for authenticated proxies (like http://user:password@proxy.com) and made a small fix to your readme (option 'tunnel' in docs is actually 'connect' in the code).